### PR TITLE
Prototype for implementing SSL for memcached.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -290,7 +290,7 @@ AC_CACHE_CHECK([for libevent directory], ac_cv_libevent_dir, [
   le_found=no
   for ledir in $trylibeventdir "" $prefix /usr/local ; do
     LDFLAGS="$saved_LDFLAGS"
-    LIBS="-levent $saved_LIBS"
+    LIBS="-levent -lssl -lcrypto $saved_LIBS"
 
     # Skip the directory if it isn't there.
     if test ! -z "$ledir" -a ! -d "$ledir" ; then
@@ -338,7 +338,7 @@ AC_CACHE_CHECK([for libevent directory], ac_cv_libevent_dir, [
 ])
   fi
 ])
-LIBS="-levent $LIBS"
+LIBS="-levent -lssl -lcrypto $LIBS"
 if test $ac_cv_libevent_dir != "(system)"; then
   if test -d "$ac_cv_libevent_dir/lib" ; then
     LDFLAGS="-L$ac_cv_libevent_dir/lib $LDFLAGS"

--- a/memcached.c
+++ b/memcached.c
@@ -1273,8 +1273,7 @@ static void complete_nread_ascii(conn *c) {
     pthread_mutex_unlock(&c->thread->stats.mutex);
 
     if ((it->it_flags & ITEM_CHUNKED) == 0) {
-        // HACK
-        if (c->ssl || strncmp(ITEM_data(it) + it->nbytes - 2, "\r\n", 2) == 0) {
+        if (strncmp(ITEM_data(it) + it->nbytes - 2, "\r\n", 2) == 0) {
             is_valid = true;
         }
     } else {
@@ -1294,8 +1293,7 @@ static void complete_nread_ascii(conn *c) {
             buf[0] = ch->prev->data[ch->prev->used - 1];
             buf[1] = ch->data[ch->used - 1];
         }
-        // HACK
-        if (c->ssl || strncmp(buf, "\r\n", 2) == 0) {
+        if (strncmp(buf, "\r\n", 2) == 0) {
             is_valid = true;
         } else {
             assert(1 == 0);
@@ -4216,8 +4214,7 @@ static void process_update_command(conn *c, token_t *tokens, const size_t ntoken
 #else
     c->ritem = ITEM_data(it);
 #endif
-    // HACK
-    c->rlbytes = it->nbytes - (c->ssl ?  1 : 0);
+    c->rlbytes = it->nbytes;
     c->cmd = comm;
     conn_set_state(c, conn_nread);
 }

--- a/memcached.h
+++ b/memcached.h
@@ -19,6 +19,8 @@
 #include <unistd.h>
 #include <assert.h>
 #include <grp.h>
+#include <openssl/ssl.h>
+#include <openssl/crypto.h>
 
 #include "itoa_ljust.h"
 #include "protocol_binary.h"
@@ -368,6 +370,9 @@ struct settings {
     int maxconns;
     int port;
     int udpport;
+    bool ssl_enabled;
+    char *ssl_srv_cert;
+    char *ssl_srv_key;
     char *inter;
     int verbose;
     rel_time_t oldest_live; /* ignore existing items older than this */
@@ -584,6 +589,9 @@ typedef struct _io_wrap {
  */
 struct conn {
     int    sfd;
+    bool is_ssl;
+    SSL_CTX* ssl_ctx;
+    SSL*     ssl;
     sasl_conn_t *sasl_conn;
     bool sasl_started;
     bool authenticated;
@@ -676,6 +684,8 @@ struct conn {
     int keylen;
     conn   *next;     /* Used for generating a list of conn structures */
     LIBEVENT_THREAD *thread; /* Pointer to the thread object serving this connection */
+    ssize_t (*read)(void  *arg, void *buf, size_t count);
+    ssize_t (*write)(void *arg, struct msghdr *msg, int flags);
 };
 
 /* array of conn structures, indexed by file descriptor */
@@ -719,6 +729,13 @@ enum store_item_type do_store_item(item *item, int comm, conn* c, const uint32_t
 conn *conn_new(const int sfd, const enum conn_states init_state, const int event_flags, const int read_buffer_size, enum network_transport transport, struct event_base *base);
 void conn_worker_readd(conn *c);
 extern int daemonize(int nochdir, int noclose);
+ssize_t read_tcp(void *arg, void *buf, size_t count);
+ssize_t write_tcp(void *arg, struct msghdr *msg, int flags);
+ssize_t ssl_read(void *arg, void *buf, size_t count);
+ssize_t ssl_write(void *arg, struct msghdr *msg, int flags);
+unsigned long get_thread_id_cb(void);
+void thread_lock_cb(int mode, int which, const char * f, int l);
+int init_ssl_locking(void);
 
 #define mutex_lock(x) pthread_mutex_lock(x)
 #define mutex_unlock(x) pthread_mutex_unlock(x)


### PR DESCRIPTION
This is a prototype of SSL for memcached. The purpose of this PR is to discuss different approaches and their trade-offs.

-Z : enables SSL.
-E : server certificate
-e : server key

$ memcached -Z -E "/home/user/cert" -e "/home/user/pkey"